### PR TITLE
アラートの調整

### DIFF
--- a/app/controllers/user_sessions_controller.rb
+++ b/app/controllers/user_sessions_controller.rb
@@ -8,7 +8,7 @@ class UserSessionsController < ApplicationController
     if @user
       redirect_to diaries_path, success: "ログインしました"
     else
-      flash.now[:alert] = "ログインに失敗しました"
+      flash.now[:danger] = "ログインに失敗しました"
       render :new, status: :unprocessable_entity
     end
   end


### PR DESCRIPTION
・ユーザー登録失敗時のエラー表示のデザインを[:alert]から[:danger]に変更（他デザインと合わせるため）